### PR TITLE
Warn about deprecation and unchecked conversion by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,12 @@ limitations under the License.
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-Xlint:deprecation</arg>
+                            <arg>-Xlint:unchecked</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updated to enable some extra warnings.
See https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html.